### PR TITLE
Fix error by adding module name

### DIFF
--- a/quarkus-spring-security-core-api/pom.xml
+++ b/quarkus-spring-security-core-api/pom.xml
@@ -10,6 +10,7 @@
 
     <groupId>io.quarkus</groupId>
     <artifactId>quarkus-spring-security-core-api</artifactId>
+    <name>Quarkus - Spring Security Core API</name>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
Now Sonatype’s new Central Portal includes PomChecker with strict validation and that does reject POMs without a element.